### PR TITLE
Now running EGCoreHandover instead of GenebuildPostHandover for EG da…

### DIFF
--- a/ensembl_prodinf/handover_tasks.py
+++ b/ensembl_prodinf/handover_tasks.py
@@ -97,11 +97,13 @@ def groups_for_uri(uri):
             production_uri=cfg.production_eg_uri
             staging_uri = cfg.staging_eg_uri
             live_uri = cfg.live_eg_uri
+            core_handover_group = cfg.core_eg_handover_group
         else:
             production_uri=cfg.production_uri
             staging_uri = cfg.staging_uri
             live_uri = cfg.live_uri
-        return [cfg.core_handover_group],None,production_uri,staging_uri,live_uri
+            core_handover_group = cfg.core_handover_group
+        return [core_handover_group],None,production_uri,staging_uri,live_uri
     elif(variation_pattern.match(uri)):
         eg_release = variation_pattern.match(uri).group(1)
         if (eg_release):

--- a/handover_config.py.example
+++ b/handover_config.py.example
@@ -20,6 +20,7 @@ production_eg_uri = os.environ.get("PRODUCTION_URI", "mysql://user@127.0.0.1:330
 compara_uri = os.environ.get("COMPARA_URI", "mysql://user@127.0.0.1:3306/")
 compara_eg_uri = os.environ.get("COMPARA_EG_URI", "mysql://user@127.0.0.1:3306/")
 core_handover_group = os.environ.get("CORE_HANDOVER_GROUP", "GenebuildPostHandover")
+core_eg_handover_group = os.environ.get("CORE_EG_HANDOVER_GROUP", "EGCoreHandover")
 variation_handover_group = os.environ.get("VARIATION_HANDOVER_GROUP", "VariationRelease")
 funcgen_handover_group = os.environ.get("FUNCGEN_HANDOVER_GROUP", "FuncgenIntegrity")
 compara_handover_group = os.environ.get("COMPARA_HANDOVER_GROUP", "ComparaIntegrity")


### PR DESCRIPTION
…tabases since some tests from GenebuildPostHandover have not been designed to work on EG databases