### PR TITLE
Fixed missing logging import in celery apps.

### DIFF
--- a/ensembl_prodinf/email_celery_app.py
+++ b/ensembl_prodinf/email_celery_app.py
@@ -1,5 +1,6 @@
-from celery import Celery
 import logging
+
+from celery import Celery, exceptions as cel_exceptions
 
 app = Celery('ensembl_prodinf',
              include=['ensembl_prodinf.email_tasks'])
@@ -7,8 +8,9 @@ app = Celery('ensembl_prodinf',
 # Load the externalised config module from PYTHONPATH
 try:
     import email_celery_app_config
+
     app.config_from_object('email_celery_app_config')
-except:
+except cel_exceptions.CeleryError:
     logging.warning('Celery email requires email_celery_app_config module')
 
 if __name__ == '__main__':

--- a/ensembl_prodinf/event_celery_app.py
+++ b/ensembl_prodinf/event_celery_app.py
@@ -1,4 +1,6 @@
-from celery import Celery
+import logging
+
+from celery import Celery, exceptions as cel_exceptions
 
 app = Celery('ensembl_prodinf',
              include=['ensembl_prodinf.event_tasks'])
@@ -6,8 +8,9 @@ app = Celery('ensembl_prodinf',
 # Load the externalised config module from PYTHONPATH
 try:
     import event_celery_app_config
+
     app.config_from_object('event_celery_app_config')
-except:
+except cel_exceptions.CeleryError:
     logging.warning('Celery email requires event_celery_app_config module')
 if __name__ == '__main__':
     app.start()

--- a/ensembl_prodinf/handover_celery_app.py
+++ b/ensembl_prodinf/handover_celery_app.py
@@ -1,4 +1,6 @@
-from celery import Celery
+import logging
+
+from celery import Celery, exceptions as cel_exceptions
 
 app = Celery('ensembl_prodinf',
              include=['ensembl_prodinf.handover_tasks'])
@@ -6,8 +8,9 @@ app = Celery('ensembl_prodinf',
 # Load the externalised config module from PYTHONPATH
 try:
     import handover_celery_app_config
+
     app.config_from_object('handover_celery_app_config')
-except:
+except cel_exceptions.CeleryError:
     logging.warning('Celery email requires handover_celery_app_config module')
 if __name__ == '__main__':
     app.start()

--- a/ensembl_prodinf/hive.py
+++ b/ensembl_prodinf/hive.py
@@ -1,27 +1,28 @@
+import json
+import re
+import time
+
 from sqlalchemy import create_engine, Column, Integer, String, ForeignKey, func
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
-from .utils import dict_to_perl_string, perl_string_to_python
 
-import time
-import json
-import re
+from .utils import dict_to_perl_string, perl_string_to_python
 
 Base = declarative_base()
 
-class Analysis(Base):
 
+class Analysis(Base):
     __tablename__ = 'analysis_base'
 
     analysis_id = Column(Integer, primary_key=True)
     logic_name = Column(String)
-    
+
     def __repr__(self):
         return "<Analysis(analysis_id='%s', logic_name='%s')>" % (
             self.analysis_id, self.logic_name)
 
-class AnalysisData(Base):
 
+class AnalysisData(Base):
     __tablename__ = 'analysis_data'
 
     analysis_data_id = Column(Integer, primary_key=True)
@@ -31,8 +32,8 @@ class AnalysisData(Base):
         return "<AnalysisData(analysis_data_id='%s', data='%s')>" % (
             self.analysis_data_id, self.data)
 
-class Result(Base):
 
+class Result(Base):
     __tablename__ = 'result'
 
     job_id = Column(Integer, primary_key=True)
@@ -45,8 +46,8 @@ class Result(Base):
         return "<Result(job_id='%s', output='%s')>" % (
             self.job_id, self.output)
 
-class JobProgress(Base):
 
+class JobProgress(Base):
     __tablename__ = 'job_progress'
 
     job_progress_id = Column(Integer, primary_key=True)
@@ -57,8 +58,8 @@ class JobProgress(Base):
         return "<JobProgress(job_progress_id='%s', job_id='%s', message='%s')>" % (
             self.job_progress_id, self.job_id, self.message)
 
-class LogMessage(Base):
 
+class LogMessage(Base):
     __tablename__ = 'log_message'
 
     log_message_id = Column(Integer, primary_key=True)
@@ -72,11 +73,11 @@ class LogMessage(Base):
         return "<LogMessage(log_message_id='%s', msg='%s')>" % (
             self.log_message_id, self.msg)
 
-class Role(Base):
 
+class Role(Base):
     __tablename__ = 'role'
 
-    role_id  = Column(Integer, primary_key=True)
+    role_id = Column(Integer, primary_key=True)
     worker_id = Column(Integer, ForeignKey("worker.worker_id"))
 
     def __repr__(self):
@@ -84,9 +85,7 @@ class Role(Base):
             self.role_id, self.worker_id)
 
 
-
 class Worker(Base):
-
     __tablename__ = 'worker'
 
     worker_id = Column(Integer, primary_key=True)
@@ -96,8 +95,8 @@ class Worker(Base):
         return "<Worker(worker_id='%s', process_id='%s')>" % (
             self.worker_id, self.process_id)
 
-class Semaphore(Base):
 
+class Semaphore(Base):
     __tablename__ = 'semaphore'
 
     semaphore_id = Column(Integer, primary_key=True)
@@ -106,19 +105,20 @@ class Semaphore(Base):
 
     def __repr__(self):
         return "<Semaphore(semaphore_id = '%s', dependent_job_id='%s', local_jobs_counter='%s')>" % (
-           self.semaphore_id, self.dependent_job_id, self.local_jobs_counter)
+            self.semaphore_id, self.dependent_job_id, self.local_jobs_counter)
 
 
 class Job(Base):
     __tablename__ = 'job'
 
-    job_id = Column(Integer(), ForeignKey("result.job_id"), ForeignKey("log_message.job_id"), primary_key=True, autoincrement=True)
+    job_id = Column(Integer(), ForeignKey("result.job_id"), ForeignKey("log_message.job_id"), primary_key=True,
+                    autoincrement=True)
     input_id = Column(String)
     status = Column(String)
     prev_job_id = Column(Integer)
     controlled_semaphore_id = Column(Integer, ForeignKey("semaphore.semaphore_id"))
     role_id = Column(Integer, ForeignKey("role.role_id"))
-    
+
     analysis_id = Column(Integer, ForeignKey("analysis_base.analysis_id"))
     analysis = relationship("Analysis", uselist=False, lazy="joined")
 
@@ -129,16 +129,21 @@ class Job(Base):
 
     def __repr__(self):
         return "<Job(job_id='%s', analysis='%s', input_id='%s', status='%s', result='%s', role=%s, when_completed=%s)>" % (
-            self.job_id, self.analysis.logic_name, self.input_id, self.status, (self.result.output if self.result!=None else None), self.role_id if self.result != None else None, self.when_completed)
+            self.job_id, self.analysis.logic_name, self.input_id, self.status,
+            (self.result.output if self.result is not None else None),
+            self.role_id if self.result is not None else None,
+            self.when_completed)
+
 
 Session = sessionmaker()
-class HiveInstance:
 
+
+class HiveInstance:
     analysis_dict = dict()
 
     def __init__(self, url, timeout=3600):
-        engine = create_engine(url, pool_recycle=timeout, echo=False)
-        Session.configure(bind=engine)
+        self.engine = create_engine(url, pool_recycle=timeout, echo=False)
+        Session.configure(bind=self.engine)
 
     def get_job_by_id(self, id):
 
@@ -146,7 +151,7 @@ class HiveInstance:
         s = Session()
         try:
             job = s.query(Job).filter(Job.job_id == id).first()
-            if(job == None):
+            if (job == None):
                 raise ValueError("Job %s not found" % id)
             job.result
             return job
@@ -167,14 +172,14 @@ class HiveInstance:
         """Get failures for all the parent and child jobs"""
         s = Session()
         try:
-           failures = {}
-           parent_job = self.get_job_by_id(id)
-           if parent_job.status == 'FAILED':
-            failures[id]=self.get_job_failure_msg_by_id(id).msg
-           for child_job in s.query(Job).filter(Job.prev_job_id == id).all():
+            failures = {}
+            parent_job = self.get_job_by_id(id)
+            if parent_job.status == 'FAILED':
+                failures[id] = self.get_job_failure_msg_by_id(id).msg
+            for child_job in s.query(Job).filter(Job.prev_job_id == id).all():
                 if child_job.status == 'FAILED':
-                    failures[child_job.job_id]=self.get_job_failure_msg_by_id(child_job.job_id).msg
-           return failures
+                    failures[child_job.job_id] = self.get_job_failure_msg_by_id(child_job.job_id).msg
+            return failures
         finally:
             s.close()
 
@@ -189,17 +194,20 @@ class HiveInstance:
             child_job = self.get_job_child(job)
             if child_job != None:
                 try:
-                    return s.query(LogMessage).filter(LogMessage.job_id == child_job.job_id).order_by(LogMessage.log_message_id.desc()).first()
+                    return s.query(LogMessage).filter(LogMessage.job_id == child_job.job_id).order_by(
+                        LogMessage.log_message_id.desc()).first()
                 finally:
                     s.close()
             else:
                 try:
-                    return s.query(LogMessage).filter(LogMessage.job_id == id).order_by(LogMessage.log_message_id.desc()).first()
+                    return s.query(LogMessage).filter(LogMessage.job_id == id).order_by(
+                        LogMessage.log_message_id.desc()).first()
                 finally:
                     s.close()
         else:
             try:
-                return s.query(LogMessage).filter(LogMessage.job_id == id).order_by(LogMessage.log_message_id.desc()).first()
+                return s.query(LogMessage).filter(LogMessage.job_id == id).order_by(
+                    LogMessage.log_message_id.desc()).first()
             finally:
                 s.close()
 
@@ -208,7 +216,7 @@ class HiveInstance:
         """ Find a workers process_id """
         s = Session()
         try:
-            return s.query(Worker).filter(Worker.worker_id==id).first()
+            return s.query(Worker).filter(Worker.worker_id == id).first()
         finally:
             s.close()
 
@@ -217,7 +225,7 @@ class HiveInstance:
         """ Find an analysis """
         s = Session()
         try:
-            return s.query(Analysis).filter(Analysis.logic_name==name).first()
+            return s.query(Analysis).filter(Analysis.logic_name == name).first()
         finally:
             s.close()
 
@@ -242,12 +250,12 @@ class HiveInstance:
             return job
         except:
             s.rollback()
-            raise        
+            raise
         finally:
             s.close()
 
     def get_analysis_data_input(self, analysis_data_id):
-        
+
         """ Get the job input stored in the analysis_data table. Get input from child job if exist"""
         s = Session()
         try:
@@ -267,7 +275,7 @@ class HiveInstance:
             s.close()
 
     def get_result_for_job_id(self, id, child=False):
-        
+
         """ Get result for a given job id. If child flag is turned on and job child exist, get result for child job"""
 
         job = self.get_job_by_id(id)
@@ -278,15 +286,15 @@ class HiveInstance:
             if child_job != None:
                 return self.get_result_for_job(child_job, progress=True)
             else:
-               return self.get_result_for_job(job, progress=True)
+                return self.get_result_for_job(job, progress=True)
         else:
             return self.get_result_for_job(job, progress=True)
 
     def get_result_for_job(self, job, progress=False):
-        
+
         """ Determine if the job has completed. If the job has semaphored children, they are also checked """
         """ Also return progress of jobs, completed and total if flag is on """
-        result = {"id":job.job_id}
+        result = {"id": job.job_id}
 
         if re.search(r"^(_extended_data_id){1}(\s){1}(\d+){1}", job.input_id):
             extended_data = job.input_id.split(" ")
@@ -294,7 +302,7 @@ class HiveInstance:
             result['input'] = perl_string_to_python(job_input.data)
         else:
             result['input'] = perl_string_to_python(job.input_id)
-        if job.status == 'DONE' and job.result!=None:
+        if job.status == 'DONE' and job.result != None:
             result['status'] = 'complete'
             result['when_completed'] = job.when_completed
             result['output'] = job.result.output_dict()
@@ -304,7 +312,6 @@ class HiveInstance:
                 result['progress'] = self.get_jobs_progress(job)
         return result
 
-
     def get_jobs_progress(self, job):
 
         """ Check data in the job_progress table """
@@ -313,22 +320,23 @@ class HiveInstance:
         """ If there is data in the job_progress table, return progress message"""
         s = Session()
         try:
-            last_job_progress_msg=s.query(JobProgress).filter(JobProgress.job_id == job.job_id).order_by(JobProgress.job_progress_id.desc()).first()
-            if last_job_progress_msg !=None:
-                total=10
-                complete=s.query(JobProgress).filter(JobProgress.job_id == job.job_id).count()
-                return {"complete":complete,"total":total,"message":last_job_progress_msg.message}
+            last_job_progress_msg = s.query(JobProgress).filter(JobProgress.job_id == job.job_id).order_by(
+                JobProgress.job_progress_id.desc()).first()
+            if last_job_progress_msg != None:
+                total = 10
+                complete = s.query(JobProgress).filter(JobProgress.job_id == job.job_id).count()
+                return {"complete": complete, "total": total, "message": last_job_progress_msg.message}
             else:
-               total=1
-               complete = 0
-               parent_job = self.get_job_by_id(job.job_id)
-               if parent_job.status == 'DONE':
-                complete +=1
-               for child_job in s.query(Job).filter(Job.prev_job_id == job.job_id).all():
-                    total +=1
+                total = 1
+                complete = 0
+                parent_job = self.get_job_by_id(job.job_id)
+                if parent_job.status == 'DONE':
+                    complete += 1
+                for child_job in s.query(Job).filter(Job.prev_job_id == job.job_id).all():
+                    total += 1
                     if child_job.status == 'DONE':
-                      complete +=1
-               return {"complete":complete,"total":total}
+                        complete += 1
+                return {"complete": complete, "total": total}
         finally:
             s.close()
 
@@ -344,7 +352,7 @@ class HiveInstance:
                 Semaphore_data = self.get_semaphore_data(semaphored_job.job_id)
         finally:
             s.close()
-        if Semaphore_data != None and Semaphore_data.local_jobs_counter>0:
+        if Semaphore_data != None and Semaphore_data.local_jobs_counter > 0:
             return self.check_semaphores_for_job(Semaphore_data)
         else:
             if job.status == 'FAILED':
@@ -386,7 +394,7 @@ class HiveInstance:
         finally:
             s.close()
 
-    def get_semaphored_jobs(self,job,status=None):
+    def get_semaphored_jobs(self, job, status=None):
 
         """ Find all jobs that are semaphored children of the nominated job, optionall filtering by status 
         'complete' indicates that all children completed successfully
@@ -398,9 +406,10 @@ class HiveInstance:
             semaphored_job = s.query(Job).filter(Job.prev_job_id == job.job_id and job.status == 'SEMAPHORED').first()
             Semaphore_data = self.get_semaphore_data(semaphored_job.job_id)
             if status == None:
-                return s.query(Job).filter(Semaphore_data.semaphore_id==Job.controlled_semaphore_id).all()
+                return s.query(Job).filter(Semaphore_data.semaphore_id == Job.controlled_semaphore_id).all()
             else:
-                return s.query(Job).filter(Semaphore_data.semaphore_id==Job.controlled_semaphore_id, Job.status == status).all()
+                return s.query(Job).filter(Semaphore_data.semaphore_id == Job.controlled_semaphore_id,
+                                           Job.status == status).all()
         finally:
             s.close()
 
@@ -411,10 +420,11 @@ class HiveInstance:
         s = Session()
         try:
             status = 'complete'
-            jobs  = dict(s.query(Job.status, func.count(Job.status)).filter(Semaphore_data.semaphore_id==Job.controlled_semaphore_id).group_by(Job.status).all())
-            if 'FAILED' in jobs and jobs['FAILED']>0:
+            jobs = dict(s.query(Job.status, func.count(Job.status)).filter(
+                Semaphore_data.semaphore_id == Job.controlled_semaphore_id).group_by(Job.status).all())
+            if 'FAILED' in jobs and jobs['FAILED'] > 0:
                 status = 'failed'
-            elif ('READY' in jobs and jobs['READY']>0) or ('RUN' in jobs and jobs['RUN']>0):
+            elif ('READY' in jobs and jobs['READY'] > 0) or ('RUN' in jobs and jobs['RUN'] > 0):
                 status = 'incomplete'
             return status
         finally:
@@ -427,25 +437,26 @@ class HiveInstance:
         try:
             jobs = s.query(Job).join(Analysis).filter(Analysis.logic_name == analysis_name).all()
             if child:
-                return list(map(lambda job: self.get_result_for_job(self.get_job_child(job)) if (self.get_job_child(job) != None) else self.get_result_for_job(job), jobs))
+                return list(map(lambda job: self.get_result_for_job(self.get_job_child(job)) if (
+                        self.get_job_child(job) != None) else self.get_result_for_job(job), jobs))
             else:
                 return list(map(lambda job: self.get_result_for_job(job), jobs))
         finally:
             s.close()
-        
+
     def delete_job(self, job, child=False):
-        
+
         """Delete a job from the hive database
            If child flag turn on, try to delete child job if exist
            Also get parent job if exist and delete it """
-        parent_job=self.get_job_parent(job)
+        parent_job = self.get_job_parent(job)
         if child:
-            child_job=self.get_job_child(job)
+            child_job = self.get_job_child(job)
             if child_job != None:
                 s = Session()
                 try:
-                    print "Deleting children job "+str(child_job.job_id)
-                    if(child_job.result != None):
+                    print "Deleting children job " + str(child_job.job_id)
+                    if (child_job.result != None):
                         s.delete(child_job.result)
                     s.delete(child_job)
                     s.commit()
@@ -457,8 +468,8 @@ class HiveInstance:
         if parent_job != None:
             s = Session()
             try:
-                print "Deleting parent job "+str(parent_job.job_id)
-                if(parent_job.result != None):
+                print "Deleting parent job " + str(parent_job.job_id)
+                if (parent_job.result != None):
                     s.delete(parent_job.result)
                 s.delete(parent_job)
                 s.commit()
@@ -469,8 +480,8 @@ class HiveInstance:
                 s.close()
         try:
             s = Session()
-            print "Deleting job "+str(job.job_id)
-            if(job.result != None):
+            print "Deleting job " + str(job.job_id)
+            if (job.result != None):
                 s.delete(job.result)
             s.delete(job)
             s.commit()


### PR DESCRIPTION
I need this fix merged in master to fix errors in travis-ci build for ensembl-prodinf-srv.

```python
ERROR: Failure: NameError (name 'logging' is not defined)
#----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/Ensembl/ensembl-prodinf-srv/tests/test_hcsrv.py", line 6, in <module>
    import hc_app
  File "/home/travis/build/Ensembl/ensembl-prodinf-srv/hc_app.py", line 12, in <module>
    from ensembl_prodinf import HiveInstance
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/ensembl_prodinf/__init__.py", line 11, in <module>
    from ensembl_prodinf.handover_celery_app import app as handover_celery_app
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/ensembl_prodinf/handover_celery_app.py", line 11, in <module>
    logging.warning('Celery email requires handover_celery_app_config module')
NameError: name 'logging' is not defined
```