### PR TITLE
Make code Python 2 and Python 3 compatible at the same time

### DIFF
--- a/ensembl_prodinf/server_utils.py
+++ b/ensembl_prodinf/server_utils.py
@@ -1,6 +1,9 @@
 import re
 import subprocess
-from urlparse import urlparse  # Python 3: from urllib.parse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 
 db_netloc_re = re.compile(r'^.+@.+:\d+$')


### PR DESCRIPTION
Since some of us in ensembl are moving to Python3, we have needed to edit this bit manually (thank you for the comment!). But this change should make everything work smoothly next time, regardless of the Python version.