### PR TITLE
Fix division check non core

### DIFF
--- a/ensembl_prodinf/handover_tasks.py
+++ b/ensembl_prodinf/handover_tasks.py
@@ -81,6 +81,8 @@ def handover_database(spec):
     if db_type not in db_types_list:
         get_logger().error("Handover failed, " + spec['src_uri'] + " has been handed over after deadline. Please contact the Production team")
         raise ValueError(spec['src_uri'] + " has been handed over after the deadline. Please contact the Production team")
+    #Check to which staging server the database need to be copied to
+    (spec,staging_uri,live_uri) = check_staging_server(spec,db_type,db_prefix,assembly)
     if 'tgt_uri' not in spec:
         spec['tgt_uri'] = get_tgt_uri(src_url,staging_uri)
     # Check that the database division match the target staging server
@@ -92,8 +94,6 @@ def handover_database(spec):
         raise ValueError('Database division '+db_division+' does not match server division list '+str(allowed_divisions_list))
     #Get database hc group and compara_uri
     (groups,compara_uri) = hc_groups(db_type,db_prefix,spec['src_uri'])
-    #Check to which staging server the database need to be copied to
-    (spec,staging_uri,live_uri) = check_staging_server(spec,db_type,db_prefix,assembly)
     #setting compara url to default value for species databases. This value is only used by Compara healthchecks
     if compara_uri is None:
         compara_uri=cfg.compara_uri + 'ensembl_compara_master'

--- a/ensembl_prodinf/handover_tasks.py
+++ b/ensembl_prodinf/handover_tasks.py
@@ -81,11 +81,13 @@ def handover_database(spec):
     if db_type not in db_types_list:
         get_logger().error("Handover failed, " + spec['src_uri'] + " has been handed over after deadline. Please contact the Production team")
         raise ValueError(spec['src_uri'] + " has been handed over after the deadline. Please contact the Production team")
+    if 'tgt_uri' not in spec:
+        spec['tgt_uri'] = get_tgt_uri(src_url,staging_uri)
     # Check that the database division match the target staging server
     if db_type in ['compara','ancestral']:
         db_division = db_prefix
     else:
-        db_division = get_division(spec['src_uri'],db_type)
+        db_division = get_division(spec['src_uri'],spec['tgt_uri'],db_type)
     if db_division not in allowed_divisions_list:
         raise ValueError('Database division '+db_division+' does not match server division list '+str(allowed_divisions_list))
     #Get database hc group and compara_uri
@@ -95,8 +97,6 @@ def handover_database(spec):
     #setting compara url to default value for species databases. This value is only used by Compara healthchecks
     if compara_uri is None:
         compara_uri=cfg.compara_uri + 'ensembl_compara_master'
-    if 'tgt_uri' not in spec:
-        spec['tgt_uri'] = get_tgt_uri(src_url,staging_uri)
     spec['staging_uri'] = staging_uri
     spec['progress_complete']=0
     get_logger().info("Handling " + str(spec))
@@ -215,13 +215,13 @@ def submit_dc(spec, src_url, db_type, db_prefix, release, staging_uri, compara_u
             get_logger().debug("Submitting DC for "+src_url.database+ " on server: "+server_url)
             dc_job_id = dc_client.submit_job(server_url, src_url.database, None, None, db_type, None, 'corelike', 'critical', None, spec['handover_token'])
         elif db_type in ['rnaseq','cdna','otherfeatures']:
-            division = get_division(spec['src_uri'],db_type)
+            division = get_division(spec['src_uri'],spec['tgt_uri'],db_type)
             get_logger().debug("division: "+division)
             get_logger().debug("Submitting DC for "+src_url.database+ " on server: "+server_url)
             dc_job_id = dc_client.submit_job(server_url, src_url.database, None, None, db_type, None, 'corelike', 'critical', None, spec['handover_token'])
         else:
             get_logger().debug("src_uri: "+spec['src_uri']+" dbtype "+db_type+" server_url "+server_url)
-            division = get_division(spec['src_uri'],db_type)
+            division = get_division(spec['src_uri'],spec['tgt_uri'],db_type)
             get_logger().debug("division: "+division)
             get_logger().debug("Submitting DC for "+src_url.database+ " on server: "+server_url)
             dc_job_id = dc_client.submit_job(server_url, src_url.database, None, None, db_type, None, db_type, 'critical', None, spec['handover_token'])

--- a/ensembl_prodinf/models/core.py
+++ b/ensembl_prodinf/models/core.py
@@ -56,9 +56,10 @@ class CoreInstance:
             self.__division = self.__get_meta_value('species.division')
         return self.__division
 
-def get_division(uri, db_type):
+def get_division(src_uri, tgt_uri, db_type):
+    uri = src_uri
     if db_type == "variation" or db_type == "funcgen":
-        uri = uri.replace("_variation_", "_core_").replace("_funcgen_","_core_")
+        uri = tgt_uri.replace("_variation_", "_core_").replace("_funcgen_","_core_")
     inst = CoreInstance(uri)
     division_meta = inst.division
     division = str(division_meta).replace('Ensembl','')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('LICENSE') as f:
 
 setup(
     name='ensembl_prodinf',
-    version='3.1.6',
+    version='3.1.7',
     description='Base libraries for Ensembl Production infrastructure services',
     long_description=readme,
     author='Dan Staines',


### PR DESCRIPTION
When checking the species division for variation or funcgen, we need to use the core database as these database type don't have the meta key. Ee can't assume that the core database is on people's server so we should check staging (tgt_uri)