### PR TITLE
Updated handover service to point to datacheck output download link i…

### DIFF
--- a/ensembl_prodinf/handover_tasks.py
+++ b/ensembl_prodinf/handover_tasks.py
@@ -293,11 +293,11 @@ def process_datachecked_db(self, dc_job_id, spec):
         raise self.retry()
     # check results
     if result['status'] == 'failed':
-        get_logger().info("Datachecks found problems, please see: "+cfg.dc_uri + "jobs/" + str(dc_job_id))
+        get_logger().info("Datachecks found problems, you can download the output here: "+cfg.dc_uri + "download_datacheck_outputs/" + str(dc_job_id))
         msg = """
 Running datachecks on %s completed but found problems.
-Please see %s
-""" % (spec['src_uri'], cfg.dc_uri + "jobs/" + str(dc_job_id))
+You can download the output here %s
+""" % (spec['src_uri'], cfg.dc_uri + "download_datacheck_outputs/" + str(dc_job_id))
         send_email(to_address=spec['contact'], subject='Datachecks found problems', body=msg, smtp_server=cfg.smtp_server)
         return
     else:


### PR DESCRIPTION
…nstead of job endpoint. This PR needs this code to be merged first: https://github.com/Ensembl/ensembl-prodinf-srv/pull/40.
Please see how the new message looks like: http://ensprod-dev-01.ebi.ac.uk:9008/#!/database_handover_result/6b785526-8fb1-11ea-b006-005056ab6d0e
<img width="1276" alt="Screenshot 2020-05-06 at 16 56 25" src="https://user-images.githubusercontent.com/5049672/81199635-d3e65c80-8fba-11ea-9ab9-4dda9344aa3d.png">
