### PR TITLE
Use requests.Session with retry in RestClient 

### DIFF
--- a/ensembl/rest_client.py
+++ b/ensembl/rest_client.py
@@ -10,168 +10,180 @@ from requests.packages.urllib3.util.retry import Retry
 
 
 class RestClient(object):
-  """
-  Base client for interacting with a standard production REST service where the URIs meet a common standard.
-  Most methods are stubs for overriding or decoration by classes that extend this for specific services
-  """
+    """
+    Base client for interacting with a standard production REST service where the URIs meet a common standard.
+    Most methods are stubs for overriding or decoration by classes that extend this for specific services
+    """
 
-  jobs = '{}/jobs'
-  jobs_id = '{}/jobs/{}'
+    jobs = '{}/jobs'
+    jobs_id = '{}/jobs/{}'
 
-  def __init__(self, uri):
-    assert_http_uri(uri)
-    self.uri = uri
-    self._session = self._make_session()
+    def __init__(self, uri):
+        assert_http_uri(uri)
+        self.uri = uri
+        self._http_adapter = self._make_HTTPAdapter()
 
-  def _make_session(self):
-      retries = Retry(total=3, backoff_factor=1,
-                      status_forcelist=[429, 500, 502, 503, 504],
-                      method_whitelist=["GET", "PUT", "POST", "DELETE"])
-      adapter = HTTPAdapter(max_retries=retries)
-      http = requests.Session()
-      http.mount("https://", adapter)
-      http.mount("http://", adapter)
-      return http
+    def _make_HTTPAdapter(self):
+        retries = Retry(total=3, backoff_factor=1,
+                        status_forcelist=[429, 500, 502, 503, 504],
+                        method_whitelist=["GET", "PUT", "POST", "DELETE"])
+        adapter = HTTPAdapter(max_retries=retries)
+        return adapter
 
-  def submit_job(self, payload):
-    """
-    Submit a job using the supplied dict as payload. No checking is carried out on the payload
-    Arguments:
-      payload : job input as dict
-    """
-    logging.info("Submitting job")
-    logging.debug(payload)
-    r = self._session.post(self.jobs.format(self.uri), json=payload)
-    r.raise_for_status()
-    return r.json()['job_id']
+    def _session(self):
+        http = requests.Session()
+        http.mount("http://", self._http_adapter)
+        return http
 
-  def delete_job(self, job_id, kill=False):
-    """
-    Delete job
-    Arguments:
-      job_id - ID of job to kill
-      kill - if True, job process should be killed
-    """
-    delete_uri = self.jobs_id.format(self.uri, str(job_id))
-    if kill:
-        params = {'kill': '1'}
-    else:
-        params = {}
-    r = self._session.delete(delete_uri, params=params)
-    if r.status_code != 200:
-        logging.error("failed to delete job because: %s", r.text)
-    r.raise_for_status()
-    return True
+    def submit_job(self, payload):
+        """
+        Submit a job using the supplied dict as payload. No checking is carried out on the payload
 
-  def list_jobs(self):
-    """
-    Find all current jobs
-    """
-    logging.info("Listing")
-    r = self._session.get(self.jobs.format(self.uri))
-    if r.status_code != 200:
-        logging.error("failed to list jobs because: %s", r.text)
-    r.raise_for_status()
-    return r.json()
+        Arguments:
+            payload : job input as dict
+        """
+        logging.info("Submitting job")
+        logging.debug(payload)
+        with self._session() as session:
+            r = session.post(self.jobs.format(self.uri), json=payload)
+        r.raise_for_status()
+        return r.json()['job_id']
 
-  def retrieve_job_failure(self, job_id):
-    """
-    Retrieve information on a job using the special format "failure" which renders failures from the supplied job.
-    The service will respond if it supports this format.
-    Arguments:
-      job_id - ID of job to retrieve
-    """
-    logging.info("Retrieving job failure for job %s", job_id)
-    r = self._session.get(self.jobs_id.format(self.uri, str(job_id)), params={'format': 'failures'})
-    if r.status_code != 200:
-        logging.error("failed to retrieve job failures because: %s", r.text)
-    r.raise_for_status()
-    failure_msg = r.json()
-    return failure_msg
+    def delete_job(self, job_id, kill=False):
+        """
+        Delete job
 
-  def retrieve_job_email(self, job_id):
-    """
-    Retrieve information on a job using the special format "email" which renders the supplied job in a format suitable
-    for sending by email.
-    The service will respond if it supports this format.
-    Arguments:
-      job_id - ID of job to retrieve
-    """
-    logging.info("Retrieving job as email for job %s", job_id)
-    r = self._session.get(self.jobs_id.format(self.uri, str(job_id)), params={'format': 'email'})
-    r.raise_for_status()
-    return r.json()
+        Arguments:
+            job_id - ID of job to kill
+            kill - if True, job process should be killed
+        """
+        delete_uri = self.jobs_id.format(self.uri, str(job_id))
+        if kill:
+            params = {'kill': '1'}
+        else:
+            params = {}
+        with self._session() as session:
+            r = session.delete(delete_uri, params=params)
+        if r.status_code != 200:
+            logging.error("failed to delete job because: %s", r.text)
+        r.raise_for_status()
+        return True
 
-  def retrieve_job(self, job_id):
-    """
-    Retrieve information on a job.
-    Arguments:
-      job_id - ID of job to retrieve
-    """
-    logging.info("Retrieving results for job %s", job_id)
-    r = self._session.get(self.jobs_id.format(self.uri, str(job_id)))
-    if r.status_code != 200:
-        logging.error("failed to retrieve job because: %s", r.text)
-    r.raise_for_status()
-    job = r.json()
-    return job
+    def list_jobs(self):
+        """
+        Find all current jobs
+        """
+        logging.info("Listing")
+        with self._session() as session:
+            r = session.get(self.jobs.format(self.uri))
+        if r.status_code != 200:
+            logging.error("failed to list jobs because: %s", r.text)
+        r.raise_for_status()
+        return r.json()
 
-  def print_job(self, job, **kwargs):
-    """
-    Stub utility to print job to logging
-    Arguments:
-      job - job object
-      print_results - ignored
-      print_input - ignored
-    """
-    logging.info(job)
+    def retrieve_job_failure(self, job_id):
+        """
+        Retrieve information on a job using the special format "failure" which renders failures from the supplied job.
+        The service will respond if it supports this format.
 
-  def write_output(self, r, output_file):
-    """
-    Utility to write response.
-    Arguments:
-      job - response object
-      output_file - output file handle
-    """
-    if (output_file != None):
-      with output_file as f:
-        f.write(r.text)
+        Arguments:
+            job_id - ID of job to retrieve
+        """
+        logging.info("Retrieving job failure for job %s", job_id)
+        with self._session() as session:
+            r = session.get(self.jobs_id.format(self.uri, str(job_id)), params={'format': 'failures'})
+        if r.status_code != 200:
+            logging.error("failed to retrieve job failures because: %s", r.text)
+        r.raise_for_status()
+        failure_msg = r.json()
+        return failure_msg
+
+    def retrieve_job_email(self, job_id):
+        """
+        Retrieve information on a job using the special format "email" which renders the supplied job in a format suitable
+        for sending by email.
+        The service will respond if it supports this format.
+
+        Arguments:
+            job_id - ID of job to retrieve
+        """
+        logging.info("Retrieving job as email for job %s", job_id)
+        with self._session() as session:
+            r = session.get(self.jobs_id.format(self.uri, str(job_id)), params={'format': 'email'})
+        r.raise_for_status()
+        return r.json()
+
+    def retrieve_job(self, job_id):
+        """
+        Retrieve information on a job.
+
+        Arguments:
+            job_id - ID of job to retrieve
+        """
+        logging.info("Retrieving results for job %s", job_id)
+        with self._session() as session:
+            r = session.get(self.jobs_id.format(self.uri, str(job_id)))
+        if r.status_code != 200:
+            logging.error("failed to retrieve job because: %s", r.text)
+        r.raise_for_status()
+        job = r.json()
+        return job
+
+    def print_job(self, job, **kwargs):
+        """
+        Stub utility to print job to logging
+
+        Arguments:
+            job - job object
+            print_results - ignored
+            print_input - ignored
+        """
+        logging.info(job)
+
+    def write_output(self, r, output_file):
+        """
+        Utility to write response.
+
+        Arguments:
+            job - response object
+            output_file - output file handle
+        """
+        if output_file is not None:
+            with output_file as f:
+                f.write(r.text)
 
 
 if __name__ == '__main__':
 
-  parser = argparse.ArgumentParser(description='Run Production jobs via a REST service')
+    parser = argparse.ArgumentParser(description='Run Production jobs via a REST service')
 
-  parser.add_argument('-u', '--uri', help='HC REST service URI', required=True)
-  parser.add_argument('-a', '--action', help='Action to take',
-                      choices=['submit', 'retrieve', 'list', 'delete', 'collate'], required=True)
-  parser.add_argument('-i', '--job_id', help='HC job identifier to retrieve')
-  parser.add_argument('-v', '--verbose', help='Verbose output', action='store_true')
-  parser.add_argument('-o', '--output_file', help='File to write output as JSON', type=argparse.FileType('w'))
-  parser.add_argument('-f', '--failure_only', help='Show failures only', action='store_true')
-  parser.add_argument('-e', '--email', help='User email')
+    parser.add_argument('-u', '--uri', help='HC REST service URI', required=True)
+    parser.add_argument('-a', '--action', help='Action to take',
+                        choices=['submit', 'retrieve', 'list', 'delete', 'collate'], required=True)
+    parser.add_argument('-i', '--job_id', help='HC job identifier to retrieve')
+    parser.add_argument('-v', '--verbose', help='Verbose output', action='store_true')
+    parser.add_argument('-o', '--output_file', help='File to write output as JSON', type=argparse.FileType('w'))
+    parser.add_argument('-f', '--failure_only', help='Show failures only', action='store_true')
+    parser.add_argument('-e', '--email', help='User email')
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  if args.verbose == True:
-    logging.basicConfig(level=logging.DEBUG, format='%(message)s')
-  else:
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG, format='%(message)s')
+    else:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
 
-  if args.uri.endswith('/') == False:
-    args.uri = args.uri + '/'
+    if not args.uri.endswith('/'):
+        args.uri = args.uri + '/'
 
-  client = RestClient(args.uri)
+    client = RestClient(args.uri)
 
-  if args.action == 'retrieve':
-    job = client.retrieve_job(args.job_id)
-    client.print_job(job, print_results=True, print_input=True)
-
-  elif args.action == 'list':
-    jobs = client.list_jobs()
-
-  elif args.action == 'delete':
-    client.delete_job(args.job_id)
-
-  else:
-    logging.error("Unknown action %s", args.action)
+    if args.action == 'retrieve':
+        job = client.retrieve_job(args.job_id)
+        client.print_job(job, print_results=True, print_input=True)
+    elif args.action == 'list':
+        jobs = client.list_jobs()
+    elif args.action == 'delete':
+        client.delete_job(args.job_id)
+    else:
+        logging.error("Unknown action %s", args.action)

--- a/ensembl_prodinf/rest_client.py
+++ b/ensembl_prodinf/rest_client.py
@@ -21,7 +21,7 @@ class RestClient(object):
     def __init__(self, uri):
         assert_http_uri(uri)
         self.uri = uri
-        self._HTTPAdapter = self._make_HTTPAdapter()
+        self._http_adapter = self._make_HTTPAdapter()
 
     def _make_HTTPAdapter(self):
         retries = Retry(total=3, backoff_factor=1,
@@ -32,7 +32,7 @@ class RestClient(object):
 
     def _session(self):
         http = requests.Session()
-        http.mount("http://", self._HTTPAdapter)
+        http.mount("http://", self._http_adapter)
         return http
 
     def submit_job(self, payload):
@@ -143,7 +143,7 @@ class RestClient(object):
           job - response object
           output_file - output file handle
         """
-        if(output_file != None):
+        if output_file is not None:
             with output_file as f:
                 f.write(r.text)
 
@@ -162,12 +162,12 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    if args.verbose == True:
+    if args.verbose:
         logging.basicConfig(level=logging.DEBUG, format='%(message)s')
     else:
         logging.basicConfig(level=logging.INFO, format='%(message)s')
 
-    if args.uri.endswith('/') == False:
+    if not args.uri.endswith('/'):
         args.uri = args.uri + '/'
 
     client = RestClient(args.uri)
@@ -175,12 +175,9 @@ if __name__ == '__main__':
     if args.action == 'retrieve':
         job = client.retrieve_job(args.job_id)
         client.print_job(job, print_results=True, print_input=True)
-
     elif args.action == 'list':
         jobs = client.list_jobs()
-
     elif args.action == 'delete':
         client.delete_job(args.job_id)
-
     else:
         logging.error("Unknown action %s", args.action)

--- a/ensembl_prodinf/rest_client.py
+++ b/ensembl_prodinf/rest_client.py
@@ -5,30 +5,9 @@ import requests
 import argparse
 import time
 from ensembl_prodinf.server_utils import assert_http_uri
-from requests.exceptions import HTTPError
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
-
-
-def retry_requests(test_func):
-    """
-    Decorator for retrying calls to API in case of Network issues
-    :param api_func: Api client function to call
-    :return:
-    """
-    def retry_call_api(*args, **kwargs):
-        retry = 1
-        max_retry = 6
-        while retry <= max_retry:
-            try:
-                return test_func(*args, **kwargs)
-            except HTTPError as e:
-                logging.warning('Call retry (%s/%s): ', retry, max_retry)
-                retry += 1
-                time.sleep(2)
-                if retry > max_retry:
-                    logging.error('API unrecoverable error after %s retry', retry-1)
-                    raise e
-    return retry_call_api
 
 class RestClient(object):
     """
@@ -42,8 +21,18 @@ class RestClient(object):
     def __init__(self, uri):
         assert_http_uri(uri)
         self.uri = uri
+        self._session = self._make_session()
 
-    @retry_requests
+    def _make_session(self):
+        retries = Retry(total=3, backoff_factor=1,
+                        status_forcelist=[429, 500, 502, 503, 504],
+                        method_whitelist=["GET", "PUT", "POST", "DELETE"])
+        adapter = HTTPAdapter(max_retries=retries)
+        http = requests.Session()
+        http.mount("https://", adapter)
+        http.mount("http://", adapter)
+        return http
+
     def submit_job(self, payload):
         """
         Submit a job using the supplied dict as payload. No checking is carried out on the payload
@@ -52,13 +41,12 @@ class RestClient(object):
         """
         logging.info("Submitting job")
         logging.debug(payload)
-        r = requests.post(self.jobs.format(self.uri), json=payload)
+        r = self._session.post(self.jobs.format(self.uri), json=payload)
         if r.status_code != 201:
-            logging.error("failed to submit because: "+r.text)
+            logging.error("failed to submit because: %s", r.text)
         r.raise_for_status()
         return r.json()['job_id']
 
-    @retry_requests
     def delete_job(self, job_id, kill=False):
         """
         Delete job
@@ -68,26 +56,26 @@ class RestClient(object):
         """
         delete_uri = self.jobs_id.format(self.uri, str(job_id))
         if kill:
-            delete_uri += '?kill=1'
-        r = requests.delete(delete_uri)
+            params = {'kill': '1'}
+        else:
+            params = {}
+        r = self._session.delete(delete_uri, params=params)
         if r.status_code != 200:
-            logging.error("failed to delete job because: "+r.text)
+            logging.error("failed to delete job because: %s", r.text)
         r.raise_for_status()
         return True
 
-    @retry_requests
     def list_jobs(self):
         """
         Find all current jobs
         """
         logging.info("Listing")
-        r = requests.get(self.jobs.format(self.uri))
+        r = self._session.get(self.jobs.format(self.uri))
         if r.status_code != 200:
-            logging.error("failed to list jobs because: "+r.text)
+            logging.error("failed to list jobs because: %s", r.text)
         r.raise_for_status()
         return r.json()
 
-    @retry_requests
     def retrieve_job_failure(self, job_id):
         """
         Retrieve information on a job using the special format "failure" which renders failures from the supplied job.
@@ -95,15 +83,14 @@ class RestClient(object):
         Arguments:
           job_id - ID of job to retrieve
         """
-        logging.info("Retrieving job failure for job " + str(job_id))
-        r = requests.get(self.jobs_id.format(self.uri, str(job_id)) + '?format=failures')
+        logging.info("Retrieving job failure for job %s", job_id)
+        r = self._session.get(self.jobs_id.format(self.uri, str(job_id)), params={'format': 'failures'})
         if r.status_code != 200:
-            logging.error("failed to retrieve job failures because: "+r.text)
+            logging.error("failed to retrieve job failures because: %s", r.text)
         r.raise_for_status()
         failure_msg = r.json()
         return failure_msg
 
-    @retry_requests
     def retrieve_job_email(self, job_id):
         """
         Retrieve information on a job using the special format "email" which renders the supplied job in a format suitable
@@ -112,27 +99,26 @@ class RestClient(object):
         Arguments:
           job_id - ID of job to retrieve
         """
-        logging.info("Retrieving job as email for job " + str(job_id))
-        r = requests.get(self.jobs_id.format(self.uri, str(job_id)) + '?format=email')
+        logging.info("Retrieving job as email for job %s", job_id)
+        r = self._session.get(self.jobs_id.format(self.uri, str(job_id)), params={'format': 'email'})
         r.raise_for_status()
         return r.json()
 
-    @retry_requests
     def retrieve_job(self, job_id):
         """
         Retrieve information on a job.
         Arguments:
           job_id - ID of job to retrieve
         """
-        logging.info("Retrieving results for job " + str(job_id))
-        r = requests.get(self.jobs_id.format(self.uri, str(job_id)))
+        logging.info("Retrieving results for job %s", job_id)
+        r = self._session.get(self.jobs_id.format(self.uri, str(job_id)))
         if r.status_code != 200:
-            logging.error("failed to retrieve job because: "+r.text)
+            logging.error("failed to retrieve job because: %s", r.text)
         r.raise_for_status()
         job = r.json()
         return job
 
-    def print_job(self, job, print_results=False, print_input=False):
+    def print_job(self, job, **kwargs):
         """
         Stub utility to print job to logging
         Arguments:
@@ -189,4 +175,4 @@ if __name__ == '__main__':
         client.delete_job(args.job_id)
 
     else:
-        logging.error("Unknown action {}".format(args.action))
+        logging.error("Unknown action %s", args.action)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 nose==1.3.7
-celery==4.3.0
-requests==2.22.0
+celery==4.4.6
+requests==2.24.0
 SQLAlchemy==1.3.10
 SQLAlchemy-Utils==0.34.2
-pika==0.10.0
-pika-pool==0.1.3


### PR DESCRIPTION
- Only the actual HTTP request is re-tried not the entire method
- Retry logic delegated to requests library (less code and implemented exponential backoff)
- Using sessions for reusing TCP connections on retries
- Easier debugging
- Update packages (celery, requests)