### PR TITLE
EP-5799: Add requests retries & log response errors in email_tasks

### DIFF
--- a/ensembl_prodinf/email_tasks.py
+++ b/ensembl_prodinf/email_tasks.py
@@ -42,7 +42,7 @@ def email_when_complete(self, url, address):
     except json.JSONDecodeError:
         err = 'Invalid response. Status: {} URL: {}'.format(response.status_code, response.url)
         logger.error('%s Body: %s', err, response.text)
-        raise Reject(err, requeue=False)
+        raise self.retry(countdown=retry_wait, max_retries=120)
     try:
         status = result['status']
         if status in ('incomplete', 'running', 'submitted'):

--- a/ensembl_prodinf/email_tasks.py
+++ b/ensembl_prodinf/email_tasks.py
@@ -45,10 +45,8 @@ def email_when_complete(self, url, address):
         raise Reject(err, requeue=False)
     try:
         status = result['status']
-        subject = result['subject']
-        body = result['body']
-    except KeyError as e:
-        err = 'Invalid response. Missing parameter "{}". URL: {}'.format(str(e), response.url)
+    except KeyError:
+        err = 'Invalid response. Missing parameter "status". URL: {}'.format(response.url)
         logger.error('%s Body: %s', err, response.text)
         raise Reject(err, requeue=False)
     if status in ('incomplete', 'running', 'submitted'):
@@ -58,8 +56,8 @@ def email_when_complete(self, url, address):
     send_email(smtp_server=smtp_server,
                from_email_address=from_email_address,
                to_address=address,
-               subject=subject,
-               body=body)
+               subject=result['subject'],
+               body=result['body'])
     return result
 
 

--- a/ensembl_prodinf/email_tasks.py
+++ b/ensembl_prodinf/email_tasks.py
@@ -51,7 +51,7 @@ def email_when_complete(self, url, address):
         err = 'Invalid response. Missing parameter "{}". URL: {}'.format(str(e), response.url)
         logger.error('%s Body: %s', err, response.text)
         raise Reject(err, requeue=False)
-    if status == 'incomplete' or status == 'running' or status == 'submitted':
+    if status in ('incomplete', 'running', 'submitted'):
         # job incomplete so retry task after waiting
         raise self.retry(countdown=retry_wait)
     # job complete so send email and complete task


### PR DESCRIPTION
- Retry for a fix term when DB Copy service is down or returning invalid data
- Log errors